### PR TITLE
use MILL_WORKSPACE_ROOT env if available

### DIFF
--- a/bindings/jni/rvls/jni/Frontend.java
+++ b/bindings/jni/rvls/jni/Frontend.java
@@ -39,6 +39,10 @@ public class Frontend  {
     public static native void close(long handle);
 
     static {
-        System.load(new File("ext/rvls/build/apps/rvls.so").getAbsolutePath());
+        if (System.getenv().containsKey("MILL_WORKSPACE_ROOT")) {
+            System.load(new File(System.getenv("MILL_WORKSPACE_ROOT") + "/ext/rvls/build/apps/rvls.so").getAbsolutePath());
+        } else {
+            System.load(new File("ext/rvls/build/apps/rvls.so").getAbsolutePath());
+        }
     }
 }


### PR DESCRIPTION
Newer mill versions support sandboxing of parallel scalatests and with that the working directory of the test is no longer fixed and the relative import of the `.so` does not work. To circumvent that I use the `MILL_WORKSPACE_ROOT` env variable if it exists.