### PR TITLE
rvls: restore NaxRiscv compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,13 @@ SRC := $(wildcard src/*.cpp)
 
 SPIKE?=../riscv-isa-sim
 SPIKE_BUILD=$(realpath ${SPIKE}/build)
+ELFIO_BUILD=$(realpath ${SPIKE}/include)
 SPIKE_OBJS:= libspike_main.a  libriscv.a  libdisasm.a  libsoftfloat.a  libfesvr.a  libfdt.a
 SPIKE_OBJS:=$(addprefix ${SPIKE_BUILD}/,${SPIKE_OBJS})
 LDFLAGS+=${SPIKE_OBJS}
 LDFLAGS += -L/usr/lib/x86_64-linux-gnu
 LIBRARIES += -lpthread -ldl -lboost_regex -lboost_system -lpthread  -lboost_system -lboost_regex 
-
+INCLUDE += -I$(realpath ${ELFIO_BUILD})
 INCLUDE += -I$(realpath ${SPIKE}/riscv)
 INCLUDE += -I$(realpath ${SPIKE}/fesvr)
 INCLUDE += -I$(realpath ${SPIKE}/softfloat)

--- a/bindings/jni/rvls/jni/Frontend.java
+++ b/bindings/jni/rvls/jni/Frontend.java
@@ -7,7 +7,7 @@ public class Frontend  {
     public static native void deleteDisassemble(long handle);
     public static native String disassemble(long handle, long instruction);
     
-    public static native long newContext(String workspace);
+    public static native long newContext(String workspace, boolean spikeLogFileOut);
     public static native void deleteContext(long handle);
 
     public static native void spikeDebug(long handle, boolean enable);
@@ -16,12 +16,13 @@ public class Frontend  {
     public static native void newCpuMemoryView(long handle, int viewId, long readIds, long writeIds);
     public static native void newCpu(long handle, int hartId, String isa, String priv, int physWidth, int memoryViewId);
     public static native void loadElf(long handle, long offset, String path);
+    public static native void loadU32(long handle, long address,  int data);
     public static native void loadBin(long handle, long offset, String path);
     public static native void setPc(long handle, int hartId, long pc);
     public static native void writeRf(long handle, int hardId, int rfKind, int address, long data);
     public static native void readRf(long handle, int hardId, int rfKind, int address, long data);
     public static native boolean commit(long handle, int hartId, long pc);
-    public static native boolean trap(long handle, int hartId, boolean interrupt, int code);
+    public static native boolean trap(long handle, int hartId, boolean interrupt, int code, long fault_addr);
     public static native String getLastErrorMessage(long handle);
     public static native void ioAccess(long handle, int hartId, boolean write, long address, long data, int mask, int size, boolean error);
     public static native void setInterrupt(long handle, int hartId, int intId, boolean value);

--- a/bindings/spinal/rvls/spinal/Tracer.scala
+++ b/bindings/spinal/rvls/spinal/Tracer.scala
@@ -72,12 +72,13 @@ class DummyBackend() extends TraceBackend{
   override def newCpuMemoryView(viewId: Int, readIds: Long, writeIds: Long) = {}
   override def newCpu(hartId: Int, isa: String, priv: String, physWidth: Int, memoryViewId: Int) = {}
   override def loadElf(offset: Long, path: File) = {}
+  override def loadU32(address: Long, data: Int) = {}
   override def loadBin(offset: Long, path: File) = {}
   override def setPc(hartId: Int, pc: Long) = {}
   override def writeRf(hardId: Int, rfKind: Int, address: Int, data: Long) = {}
   override def readRf(hardId: Int, rfKind: Int, address: Int, data: Long) = {}
   override def commit(hartId: Int, pc: Long) = {}
-  override def trap(hartId: Int, interrupt: Boolean, code: Int) = {}
+  override def trap(hartId: Int, interrupt: Boolean, code: Int, fault_addr: Long) = {}
   override def ioAccess(hartId: Int, access: TraceIo) = {}
   override def setInterrupt(hartId: Int, intId: Int, value: Boolean) = {}
   override def addRegion(hartId: Int, kind : Int, base: Long, size: Long) = {}
@@ -105,8 +106,8 @@ class FileBackend(f : File) extends TraceBackend{
     log(f"rv commit $hartId $pc%016x\n")
   }
 
-  override def trap(hartId: Int, interrupt : Boolean, code : Int): Unit ={
-    log(f"rv trap $hartId ${interrupt.toInt} $code\n")
+  override def trap(hartId: Int, interrupt : Boolean, code : Int, fault_addr: Long): Unit ={
+    log(f"rv trap $hartId ${interrupt.toInt} $code $fault_addr%016x\n")
   }
 
   override def writeRf(hartId: Int, rfKind: Int, address: Int, data: Long) = {
@@ -127,6 +128,10 @@ class FileBackend(f : File) extends TraceBackend{
 
   override def addRegion(hartId: Int, kind: Int, base: Long, size: Long) = {
     log(f"rv region add $hartId $kind $base%016x $size%016x\n")
+  }
+
+  override def loadU32(address: Long, data: Int): Unit = {
+    log(f"U32 load  $address%016x $data")
   }
 
   override def loadElf(offset: Long, path: File) = {
@@ -174,10 +179,10 @@ class FileBackend(f : File) extends TraceBackend{
   override def close() = bf.close()
 }
 
-class RvlsBackend(workspace : File = new File(".")) extends TraceBackend{
+class RvlsBackend(workspace : File = new File("."), spikeLogFileOut: Boolean) extends TraceBackend{
   import rvls.jni.Frontend
   FileUtils.forceMkdir(workspace)
-  val handle = Frontend.newContext(workspace.getAbsolutePath)
+  val handle = Frontend.newContext(workspace.getAbsolutePath,spikeLogFileOut)
 
   override def flush(): Unit = {}
   override def close(): Unit = {
@@ -194,6 +199,7 @@ class RvlsBackend(workspace : File = new File(".")) extends TraceBackend{
   override def newCpuMemoryView(viewId: Int, readIds: Long, writeIds: Long): Unit = Frontend.newCpuMemoryView(handle, viewId, readIds, writeIds)
   override def newCpu(hartId: Int, isa: String, priv: String, physWidth: Int, memoryViewId: Int): Unit = Frontend.newCpu(handle, hartId, isa, priv, physWidth, memoryViewId)
   override def loadElf(offset: Long, path: File): Unit = Frontend.loadElf(handle, offset, path.getAbsolutePath)
+  override def loadU32(address: Long, data: Int): Unit = Frontend.loadU32(handle, address, data)
   override def loadBin(offset: Long, path: File): Unit = Frontend.loadBin(handle, offset, path.getAbsolutePath)
   override def setPc(hartId: Int, pc: Long): Unit = Frontend.setPc(handle, hartId, pc)
   override def writeRf(hardId: Int, rfKind: Int, address: Int, data: Long): Unit = Frontend.writeRf(handle, hardId, rfKind, address, data)
@@ -201,7 +207,7 @@ class RvlsBackend(workspace : File = new File(".")) extends TraceBackend{
   override def commit(hartId: Int, pc: Long): Unit = if(!Frontend.commit(handle, hartId, pc)) {
     throw new Exception(Frontend.getLastErrorMessage(handle))
   }
-  override def trap(hartId: Int, interrupt: Boolean, code: Int): Unit = if(!Frontend.trap(handle, hartId, interrupt, code)) {
+  override def trap(hartId: Int, interrupt: Boolean, code: Int, fault_addr: Long): Unit = if(!Frontend.trap(handle, hartId, interrupt, code, fault_addr)){
     throw new Exception(Frontend.getLastErrorMessage(handle))
   }
   override def ioAccess(hartId: Int, access: TraceIo): Unit = Frontend.ioAccess(handle, hartId, access.write, access.address, access.data, access.mask, access.size, access.error)

--- a/src/ascii_frontend.cpp
+++ b/src/ascii_frontend.cpp
@@ -82,9 +82,10 @@ void checkFile(std::ifstream &lines, RvlsConfig &config){
                     rv->ioAccess(io);
                 } else if (str == "trap") {
                     u32 hartId, code;
+                    u64 address;
                     bool interrupt;
-                    f >> hartId >> interrupt >> code;
-                    rv->trap(interrupt, code);
+                    f >> hartId >> interrupt >> code >> address;
+                    rv->trap(interrupt, code, address);
                 } else if (str == "int") {
                     f >> str;
                     if(str == "set") {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,5 +1,10 @@
 #include "context.hpp"
 
+void Context::loadU32(u64 address, u32 data){
+    memory.write(address, 4, (uint8_t*)&data);
+}
+
+
 void Context::loadElf(std::string path, u64 offset){
     auto elf = new Elf(path.c_str());
     elf->visitBytes([&](u8 data, u64 address) {

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -18,7 +18,7 @@ public:
     FILE *spikeLogs;
     u64 time = 0xFFFFFFFFFFFFFFFF;
     std::string lastErrorMessage;
-
+    void loadU32(u64 address, u32 data);
     void loadElf(std::string path, u64 offset);
     void loadBin(std::string path, u64 offset);
     void cpuMemoryViewNew(u32 id, u64 readIds, u64 writeIds);

--- a/src/hart.cpp
+++ b/src/hart.cpp
@@ -132,7 +132,7 @@ Hart::Hart(u32 hartId, string isa, string priv, u32 physWidth, CpuMemoryView *me
     this->physWidth = physWidth;
     std::ofstream outfile ("/dev/null",std::ofstream::binary);
     this->cfg.isa = isa_hart.c_str();
-    this->cfg.priv = priv_hart.c_str(); 
+    this->cfg.priv = priv_hart.c_str();
     this->cfg.misaligned = false;
     this->cfg.pmpregions = 0;
     this->cfg.hartids.push_back(hartId);
@@ -146,6 +146,12 @@ Hart::Hart(u32 hartId, string isa, string priv, u32 physWidth, CpuMemoryView *me
     state = proc->get_state();
     state->csrmap[CSR_MCYCLE] = std::make_shared<basic_csr_t>(proc, CSR_MCYCLE, 0);
     state->csrmap[CSR_MCYCLEH] = std::make_shared<basic_csr_t>(proc, CSR_MCYCLEH, 0);
+    for(int i = 0;i < 32;i++){
+        float128_t tmp;
+        tmp.v[0] = -1;
+        tmp.v[1] = -1;
+        state->FPR.write(i, tmp);
+    }
 }
 
 void Hart::close() {
@@ -168,6 +174,11 @@ void Hart::writeRf(u32 rfKind, u32 address, u64 data){
         floatWriteData = data;
         break;
     case 4:
+        if((csrAddress == CSR_FCSR || csrAddress == CSR_FRM || csrAddress == CSR_FFLAGS) && address == CSR_MSTATUS){
+            fsDirty = true;
+            fsCsrAddress = address;
+            break;
+        }
         if((csrWrite || csrRead) && csrAddress != address){
         	failure("duplicated CSR access \n");
         }
@@ -201,16 +212,41 @@ void Hart::readRf(u32 rfKind, u32 address, u64 data){
 }
 
 void Hart::physExtends(u64 &v){
-    v = (u64)(((s64)v<<(64-physWidth)) >> (64-physWidth));
+    //v = (u64)(((s64)v<<(64-physWidth)) >> (64-physWidth));
+    auto xlen = proc->get_xlen();
+    if(xlen == 32){
+        v = (u64)(((s64)v<<(64-physWidth)) >> (64-physWidth));
+    }
+    else{
+        v = (s64)v;
+    }
 }
 
-void Hart::trap(bool interrupt, u32 code){
+void Hart::trap(bool interrupt, u32 code, u64 address){
     int mask = 1 << code;
     auto fromPc = state->pc;
+    bool pageFault = !interrupt && (code == 12 || code == 13 || code == 15);
+//    printf("DUT did trap at tval: 0x%lx pc: %lx code %d\n", address, fromPc, code);
+     if(pageFault){
+        auto mmu = proc->get_mmu();
+        mmu->flush_tlb();
+        mmu->fault_fetch = code == 12;
+        mmu->fault_load  = code == 13;
+        mmu->fault_store = code == 15;
+        mmu->fault_address = address;
+    }
+
     if(interrupt) state->mip->write_with_mask(mask, mask);
     proc->step(1);
     if(interrupt) state->mip->write_with_mask(mask, 0);
+    if(pageFault){
+        auto mmu = proc->get_mmu();
+        mmu->fault_fetch = false;
+        mmu->fault_load  = false;
+        mmu->fault_store = false;
+    }
     if(!state->trap_happened){
+//        printf("DUT did trap on %lx Code %d\n", fromPc, code);
         failure("DUT did trap on %lx\n", fromPc);
     }
 
@@ -221,8 +257,8 @@ void Hart::trap(bool interrupt, u32 code){
 }
 
 void Hart::commit(u64 pc){
-	//auto shift = 64-proc->get_xlen();
-    //if(pc != (state->pc << shift >> shift)){
+//	auto shift = 64-proc->get_xlen();
+//  if(pc != (state->pc << shift >> shift)){
     if(pc != state->pc ){
     	failure("PC MISSMATCH dut=%lx ref=%lx\n", pc, state->pc);
     }
@@ -260,6 +296,10 @@ void Hart::commit(u64 pc){
         }
     }
 
+//    Check
+//    printf("**************************************************\n");
+//    printf("PC = %016lx, ref=%lx, INST = %08lx\n", pc, state->pc, state->last_inst.bits());
+
     //Run the spike model
     proc->step(1);
     memory->step();
@@ -267,6 +307,7 @@ void Hart::commit(u64 pc){
     //Sync back some CSR
     state->mip->unlogged_write_with_mask(-1, 0);
     if(csrRead){
+//        printf("Debug: CSR read - address: %x, data: %lx\n", csrAddress, csrReadData);
         switch(csrAddress){
         case MIP:
         case SIP:
@@ -278,53 +319,76 @@ void Hart::commit(u64 pc){
 
     //Checks
 //        printf("%016lx %08lx\n", pc, state->last_inst.bits());
-    assertTrue("DUT missed a trap", !state->trap_happened);
-    for (auto item : state->log_reg_write) {
-        if (item.first == 0)
-          continue;
+    assertTrue("DUT missed a trap", !((u32)state->trap_happened));
+    int i = 0;
+   for (auto item : state->log_reg_write) {
+//    printf("LOG N°%u :Debug: LOOP rd = %u, data = %lx, dut_floatData: %lx, dut_floatValid: %u\n", i, (u32)item.first >> 4, item.second.v[0], floatWriteData, floatWriteValid);
+    if (item.first == 0)
+        continue;
 
-        u32 rd = item.first >> 4;
-        switch (item.first & 0xf) {
-        case 0: { //integer
-            assertTrue("INTEGER WRITE MISSING", integerWriteValid);
-            assertEq("INTEGER WRITE MISSMATCH", integerWriteData, item.second.v[0]);
-            integerWriteValid = false;
-        } break;
-        case 1: { //float
-            assertTrue("FLOAT WRITE MISSING", floatWriteValid);
-            assertEq("FLOAT WRITE MISSMATCH", floatWriteData, item.second.v[0]);
-            floatWriteValid = false;
-        } break;
-        case 4:{ //CSR
-            u64 inst = state->last_inst.bits();
-            switch(inst){
-            case 0x30200073: //MRET
-            case 0x10200073: //SRET
-            case 0x00200073: //URET
-                physExtends(state->pc);
-                break;
-            default:{
-                if((inst & 0x7F) == 0x73 && (inst & 0x3000) != 0){
-                    assertTrue("CSR WRITE MISSING", csrWrite);
-                    assertEq("CSR WRITE ADDRESS", (u32)(csrAddress & 0xCFF), (u32)(rd & 0xCFF));
-//                                                assertEq("CSR WRITE DATA", whitebox->robCtx[robId].csrWriteData, item.second.v[0]);
-                }
-                break;
-            }
+    i += 1;
 
-            }
-            csrWrite = false;
-        } break;
+    u32 rd = item.first >> 4;
+
+//    printf("LOG N°%u :Debug: LOOP rd = %u, data = %lx, dut_floatData: %lx, dut_floatValid: %u\n", i, rd, item.second.v[0], floatWriteData, floatWriteValid);
+
+    switch (item.first & 0xf) {
+    case 0: { //integer
+//        printf("Debug: Integer write detected, rd = %u, data = %lx, dut_integerData: %lx\n", rd, item.second.v[0], integerWriteData);
+        assertTrue("INTEGER WRITE MISSING", integerWriteValid);
+        assertEq("INTEGER WRITE MISSMATCH", integerWriteData, item.second.v[0]);
+        integerWriteValid = false;
+    } break;
+
+    case 1: { //float
+//        printf("item.second.v[0] = %lx, item.second.v[1] = %lx\n",item.second.v[0], item.second.v[1]);
+//        printf("Debug: Float write detected, rd = %u, data = %lx, dut_floatData: %lx, dut_floatValid: %u\n", rd, item.second.v[0], floatWriteData, floatWriteValid);
+        assertTrue("FLOAT WRITE MISSING", floatWriteValid);
+        assertEq("FLOAT WRITE MISSMATCH", floatWriteData, item.second.v[0]);
+        floatWriteValid = false;
+    } break;
+
+    case 4: { //CSR
+        u64 inst = state->last_inst.bits();
+//        printf("Debug: CSR write detected, inst = %lx, rd = %u\n", inst, rd);
+
+        switch (inst) {
+        case 0x30200073: // MRET
+        case 0x10200073: // SRET
+        case 0x00200073: // URET
+//            printf("Debug: Handling MRET/SRET/URET instruction\n");
+            physExtends(state->pc);
+            break;
         default: {
-            failure("??? unknown spike trace %lx\n", item.first & 0xf);
-        } break;
-        }
-    }
+            if ((inst & 0x7F) == 0x73 && (inst & 0x3000) != 0) {
+//                printf("Debug: CSR instruction detected, inst = %lx, CSR address = %x\n", inst, csrAddress);
 
-    csrRead = false;
-    assertTrue("CSR WRITE SPAWNED", !csrWrite);
-    assertTrue("INTEGER WRITE SPAWNED", !integerWriteValid);
-    assertTrue("FLOAT WRITE SPAWNED", !floatWriteValid);
+                if ((inst >> 20) == CSR_FCSR || (inst >> 20) == CSR_FRM || (inst >> 20) == CSR_FFLAGS) {
+                    if (rd != CSR_MSTATUS) {
+                        assertTrue("CSR WRITE MISSING", csrWrite);
+                        assertEq("CSR WRITE ADDRESS", (u32)(csrAddress & 0xCFF), (u32)(rd & 0xCFF));
+//                                                assertEq("CSR WRITE DATA", whitebox->robCtx[robId].csrWriteData, item.second.v[0]);
+                    }
+                    break;
+                }
+                assertTrue("CSR WRITE MISSING", csrWrite);
+                assertEq("CSR WRITE ADDRESS", (u32)(csrAddress & 0xCFF), (u32)(rd & 0xCFF));
+            }
+            break;
+        }
+        }
+        csrWrite = false;
+    } break;
+    default: {
+        failure("??? unknown spike trace %lx\n", item.first & 0xf);
+    } break;
+    }
+}
+
+csrRead = false;
+assertTrue("CSR WRITE SPAWNED", !csrWrite);
+assertTrue("INTEGER WRITE SPAWNED", !integerWriteValid);
+assertTrue("FLOAT WRITE SPAWNED", !floatWriteValid);
 }
 
 void Hart::ioAccess(TraceIo io){
@@ -341,5 +405,6 @@ void Hart::scStatus(bool failure){
 }
 
 void Hart::addRegion(Region r){
+//    printf("Type: %d Base %lx Size %lx\n", r.type, r.base, r.size);
     sif->regions.push_back(r);
 }

--- a/src/hart.hpp
+++ b/src/hart.hpp
@@ -96,6 +96,9 @@ public:
     u64 csrWriteData = 0;
     u64 csrReadData = 0;
 
+    u32 fsCsrAddress = 0;
+    bool fsDirty = false;
+
     bool scValid = false;
     bool scFailure = false;
 
@@ -106,7 +109,7 @@ public:
     void writeRf(u32 rfKind, u32 address, u64 data);
     void readRf(u32 rfKind, u32 address, u64 data);
     void physExtends(u64 &v);
-    void trap(bool interrupt, u32 code);
+    void trap(bool interrupt, u32 code, u64 address);
     void commit(u64 pc);
     void ioAccess(TraceIo io);
     void setInt(u32 id, bool value);

--- a/src/jni_frontend.cpp
+++ b/src/jni_frontend.cpp
@@ -52,10 +52,10 @@ JNIEXPORT void JNICALL Java_rvls_jni_Frontend_deleteDisassemble(JNIEnv * env, jo
 }
 
 
-JNIEXPORT jlong JNICALL Java_rvls_jni_Frontend_newContext(JNIEnv * env, jobject obj, jstring jworkspace){
+JNIEXPORT jlong JNICALL Java_rvls_jni_Frontend_newContext(JNIEnv * env, jobject obj, jstring jworkspace, jboolean spikeLogFileOut){
 	string workspace = toString(env, jworkspace);
 	auto *ctx = new Context();
-	ctx->spikeLogs = fopen((workspace + "/spike.log").c_str(), "w");
+	ctx->spikeLogs = fopen((spikeLogFileOut ? (workspace + "/spike.log") : "/dev/null").c_str(), "w");
     return (jlong)ctx;
 }
 
@@ -98,6 +98,10 @@ rvlsJni(loadBin), long offset, jstring path){
 	c->loadBin(toString(env, path), offset);
 }
 
+rvlsJni(loadU32), long address, int data){
+	c->loadU32(address, data);
+}
+
 rvlsJni(setPc), int hartId, long pc){
 	rv->setPc(pc);
 }
@@ -117,9 +121,10 @@ rvlsJniBool(commit), int hartId, long pc) {
 	}
 	return true;
 }
-rvlsJniBool(trap), int hartId, jboolean interrupt, int code) {
+
+rvlsJniBool(trap), int hartId, jboolean interrupt, int code, long address) {
 	try{
-		rv->trap(interrupt, code);
+		rv->trap(interrupt, code, address);
 	} catch (const std::exception &e) {
 		c->lastErrorMessage = e.what();
 	    return false;


### PR DESCRIPTION
Patch-By: Bill94l <billal.ighilahriz@gmail.com>
Based-on: NaxRiscv rvls.{diff,patch}
Applied-by: Christian Klarhorst <cklarhor@techfak.uni-bielefeld.de>

I applied the patch and rebased it onto the current NaxRiscv branch.

logging FCSR write register
initialize floating registers and update FCSR assertion Update rvls tracer
Merge remote-tracking branch 'my-github-rvls/updated-spike' into patch_local_rvls Added  to support FPU tests with SocSim, and extended the  method to include  for logging the trap address. This change allows more detailed information to be captured during trap handling.
Removed the shift operation because it caused a mismatch in 32-bit mode. - For example, with pc=0xffffffff8000017c and state->pc=0xffffffff8000017c, - a 32-bit shift was applied, resulting in a mismatch. This was problematic in SocSim. Update RVLS for compatibility with the updated Spike version