### PR TITLE
Remove -lboost_system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SPIKE_OBJS:= libspike_main.a  libriscv.a  libdisasm.a  libsoftfloat.a  libfesvr.
 SPIKE_OBJS:=$(addprefix ${SPIKE_BUILD}/,${SPIKE_OBJS})
 LDFLAGS+=${SPIKE_OBJS}
 LDFLAGS += -L/usr/lib/x86_64-linux-gnu
-LIBRARIES += -lpthread -ldl -lboost_regex -lboost_system -lpthread  -lboost_system -lboost_regex 
+LIBRARIES += -lpthread -ldl -lboost_regex -lpthread  -lboost_regex 
 
 INCLUDE += -I$(realpath ${SPIKE}/riscv)
 INCLUDE += -I$(realpath ${SPIKE}/fesvr)


### PR DESCRIPTION
According to:
https://github.com/boostorg/boost/issues/1071
boost_system is a head only library since Boost 1.69 (2018) and -lboost_system is a stub only.
Since boost 1.89  the stub is removed and the build fails.