### PR TITLE
Multiple core rvls verification support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ There are mostly 3 kinds of RISC-V related commands :
 `rv set pc $hartId $pc_hex`
 - Used once after reset to specify where the CPU PC landed
 
+`rv set reg $hartId x$id $value_hex`
+- Set an integer register before execution. Writes to x0 are ignored.
+- RV32 values use their low 32 bits and are sign-extended in the reference model.
+
 `rv commit $hartId $pc_hex`
 - Specify when a given hart committed an instruction
 

--- a/bindings/jni/rvls/jni/Frontend.java
+++ b/bindings/jni/rvls/jni/Frontend.java
@@ -6,7 +6,7 @@ public class Frontend  {
     public static native long newDisassemble(int xlen);
     public static native void deleteDisassemble(long handle);
     public static native String disassemble(long handle, long instruction);
-    
+
     public static native long newContext(String workspace);
     public static native void deleteContext(long handle);
 
@@ -19,6 +19,7 @@ public class Frontend  {
     public static native void loadBin(long handle, long offset, String path);
     public static native void loadBytes(long handle, long offset, byte[] bytes);
     public static native void setPc(long handle, int hartId, long pc);
+    public static native void setRegister(long handle, int hartId, int id, long value);
     public static native void writeRf(long handle, int hardId, int rfKind, int address, long data);
     public static native void readRf(long handle, int hardId, int rfKind, int address, long data);
     public static native boolean commit(long handle, int hartId, long pc);

--- a/bindings/spinal/rvls/spinal/Tracer.scala
+++ b/bindings/spinal/rvls/spinal/Tracer.scala
@@ -42,6 +42,7 @@ trait TraceBackend{
   def loadBin(offset: Long, path: File): Unit
   def loadBytes(offset: Long, bytes: Array[Byte]): Unit
   def setPc(hartId : Int, pc : Long): Unit
+  def setRegister(hartId : Int, id : Int, value : Long): Unit
   def writeRf(hardId : Int, rfKind : Int, address : Int, data : Long) //address out of range mean unknown
   def readRf(hardId : Int, rfKind : Int, address : Int, data : Long) //address out of range mean unknown
   def commit(hartId : Int, pc : Long, instruction : Long): Unit
@@ -77,6 +78,7 @@ class DummyBackend() extends TraceBackend{
   override def loadBin(offset: Long, path: File) = {}
   override def loadBytes(offset: Long, bytes: Array[Byte]): Unit = {}
   override def setPc(hartId: Int, pc: Long) = {}
+  override def setRegister(hartId : Int, id : Int, value : Long) = {}
   override def writeRf(hardId: Int, rfKind: Int, address: Int, data: Long) = {}
   override def readRf(hardId: Int, rfKind: Int, address: Int, data: Long) = {}
   override def commit(hartId: Int, pc: Long, instruction : Long) = {}
@@ -149,6 +151,10 @@ class FileBackend(f : File) extends TraceBackend{
     log(f"rv set pc $hartId $pc%016x\n")
   }
 
+  override def setRegister(hartId : Int, id : Int, value : Long) = {
+    log(f"rv set reg $hartId x$id $value%016x\n")
+  }
+
   override def newCpuMemoryView(memoryViewId : Int, readIds : Long, writeIds : Long) = {
     log(f"memview new $memoryViewId $readIds $writeIds\n")
   }
@@ -209,6 +215,7 @@ class RvlsBackend(workspace : File = new File(".")) extends TraceBackend{
   override def loadBin(offset: Long, path: File): Unit = Frontend.loadBin(handle, offset, path.getAbsolutePath)
   override def loadBytes(offset: Long, bytes: Array[Byte]): Unit = Frontend.loadBytes(handle, offset, bytes)
   override def setPc(hartId: Int, pc: Long): Unit = Frontend.setPc(handle, hartId, pc)
+  override def setRegister(hartId : Int, id : Int, value : Long): Unit = Frontend.setRegister(handle, hartId, id, value)
   override def writeRf(hardId: Int, rfKind: Int, address: Int, data: Long): Unit = Frontend.writeRf(handle, hardId, rfKind, address, data)
   override def readRf(hardId: Int, rfKind: Int, address: Int, data: Long): Unit = Frontend.readRf(handle, hardId, rfKind, address, data)
   override def commit(hartId: Int, pc: Long, instruction: Long): Unit = if(!Frontend.commit(handle, hartId, pc)) {

--- a/src/ascii_frontend.cpp
+++ b/src/ascii_frontend.cpp
@@ -106,6 +106,16 @@ void checkFile(std::ifstream &lines, RvlsConfig &config){
                         u64 pc;
                         f >> hartId >> hex >> pc >> dec;
                         rv->setPc(pc);
+                    } else if(str == "reg"){
+                        u32 hartId;
+                        s32 id;
+                        u64 value;
+                        char prefix;
+                        f >> hartId >> prefix >> id >> hex >> value >> dec;
+                        if(!f || prefix != 'x'){
+                            throw runtime_error(line);
+                        }
+                        rv->setRegister(id, value);
                     } else {
                         throw runtime_error(line);
                     }

--- a/src/hart.cpp
+++ b/src/hart.cpp
@@ -503,6 +503,7 @@ void Hart::commit(u64 pc){
     }
     //Run the spike model
     proc->step(1);
+    proc->clear_waiting_for_interrupt();
     memory->step();
 
     //Sync back some CSR

--- a/src/hart.cpp
+++ b/src/hart.cpp
@@ -291,6 +291,21 @@ void Hart::setPc(u64 pc){
     state->pc = pc;
 }
 
+void Hart::setRegister(s32 id, u64 value){
+    if(id < 0 || id >= NXPR){
+        throw std::invalid_argument("Integer register id must be between 0 and 31");
+    }
+
+    if(proc->get_xlen() == 32){
+        value &= 0xffffffffULL;
+        if(value & 0x80000000ULL){
+            value |= 0xffffffff00000000ULL;
+        }
+    }
+
+    state->XPR.write(id, value);
+}
+
 static const reg_t dump_csrs[] = {
     CSR_SSTATUS, CSR_SIE, CSR_STVEC, CSR_SCOUNTEREN,
     CSR_SSCRATCH, CSR_SEPC, CSR_SCAUSE, CSR_STVAL, CSR_SIP, CSR_SATP,

--- a/src/hart.hpp
+++ b/src/hart.hpp
@@ -111,6 +111,7 @@ public:
     Hart(u32 hartId, string isa, string priv, u32 physWidth, u32 pmpNum, u32 triggerCount, u32 asidWidth, CpuMemoryView *memory, FILE *logs);
     void close();
     void setPc(u64 pc);
+    void setRegister(s32 id, u64 value);
     void writeRf(u32 rfKind, u32 address, u64 data);
     void readRf(u32 rfKind, u32 address, u64 data);
     void physExtends(u64 &v);

--- a/src/jni_frontend.cpp
+++ b/src/jni_frontend.cpp
@@ -118,6 +118,17 @@ rvlsJni(loadBytes), long offset, jbyteArray array){
 rvlsJni(setPc), int hartId, long pc){
 	rv->setPc(pc);
 }
+rvlsJni(setRegister), int hartId, int id, long value){
+    try{
+        rv->setRegister(id, value);
+    } catch (const std::exception &e) {
+        auto exception = env->FindClass("java/lang/IllegalArgumentException");
+        if(exception != nullptr){
+            env->ThrowNew(exception, e.what());
+            env->DeleteLocalRef(exception);
+        }
+    }
+}
 rvlsJni(writeRf), int hartId, int rfKind, int address, long data){
 	rv->writeRf(rfKind, address, data);
 }


### PR DESCRIPTION
This is needed to run a two-core buildroot test

The first commit fix a wfi restore problem, which will occur on multiple cores.
The second commit add a function to set integer register for the cores.